### PR TITLE
URA-569 eggd vep uranus config v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # eggd_vep_uranus_config
+
+This repo contains a JSON configuration file for the implementation of VEP for the HaemOnc assay.
+
+## What does the JSON config do?
+Configuration file required to annotate a vcf using Variant Effect Predictor implementation eggd_vep.
+
+A variable level of annotation can be achieved by different combinations of custom annotations and vep plugins, in addition to the required VEP resources.
+
+## What does the JSON config version contain?
+This json file provides information about annotations,plugins, required fields and the genome version.
+
+* Genome build: GRCh38
+* VEP required files:
+    * vep_v103.1_docker.tar.gz
+    * homo_sapiens_refseq_vep_103_GRCh38.tar.gz
+    * plugin_config.txt
+    * Homo_sapiens.GRCh38.dna.toplevel.fa.gz
+    * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai
+    * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi
+    * GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz
+* Custom Annotation sources:
+    * clinvar_20231217_hg38_withchr.vcf.gz
+    * uranus_v2_panel_sorted_int.bed.gz
+    * haemonc_1706_samples.vcf.gz
+* Plugin annotations:
+    * whole_genome_SNVs.tsv.gz
+    * gnomad.genomes.r3.0.indel.tsv.gz
+
+Notes
+How to check the names of all the files included in the config:
+
+```bash
+config_file=you_file_name.json
+
+# Get the Vep Resources filenames
+for file in  $(jq -r ' .vep_resources | .[]' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+
+# Get Custom Annotation filenames
+for file in  $(jq -r ' .custom_annotations[]|.resource_files[]|.file_id' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+
+# Get Plugin Annotation filenames
+for file in  $(jq -r ' .plugins[]|.resource_files[]|.file_id' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+```

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ This json file provides information about annotations,plugins, required fields a
     * GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz
 * Custom Annotation sources:
     * ClinVar
-        * clinvar_20231217_hg38_withchr.vcf.gz
+        * clinvar_20240215_GRCh38.vcf.gz
     * gnomAD
         *   gnomad.exomes.r2.1.1.sites.all.liftover_grch38.trimmed_normalised_decomposed_PASS.vcf.bgz
     * COSMIC
-        * CosmicCodingMuts_GRCh38_v94.normal.vcf.gz
-        * CosmicNonCodingVariants_GRCh38_v94.normal.vcf.gz
-    * uranus_v2_panel_sorted_int.bed.gz
+        * CosmicCodingMuts_GRCh38_v99.normal.vcf.gz
+        * CosmicNonCodingVariants_GRCh38_v99.normal.vcf.gz
+    * uranus_panel_v2_annotation_for_vep.bed.gz
     * haemonc_1706_samples.vcf.gz
 * Plugin annotations:
     * CADD

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This json file provides information about annotations,plugins, required fields a
 * Custom Annotation sources:
     * ClinVar
         * clinvar_20231217_hg38_withchr.vcf.gz
+    * gnomAD
+        *   gnomad.exomes.r2.1.1.sites.all.liftover_grch38.trimmed_normalised_decomposed_PASS.vcf.bgz
     * COSMIC
         * CosmicCodingMuts_GRCh38_v94.normal.vcf.gz
         * CosmicNonCodingVariants_GRCh38_v94.normal.vcf.gz
@@ -31,8 +33,6 @@ This json file provides information about annotations,plugins, required fields a
     * CADD
         * whole_genome_SNVs.tsv.gz
         * gnomad.genomes.r3.0.indel.tsv.gz
-* VEP Annotation
-    * gnomad_AF (exome)
 
 Notes
 How to check the names of all the files included in the config:

--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ This json file provides information about annotations,plugins, required fields a
     * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi
     * GRCh38.no_alt_analysis_set_chr_mask21.fasta-index.tar.gz
 * Custom Annotation sources:
-    * clinvar_20231217_hg38_withchr.vcf.gz
+    * ClinVar
+        * clinvar_20231217_hg38_withchr.vcf.gz
+    * COSMIC
+        * CosmicCodingMuts_GRCh38_v94.normal.vcf.gz
+        * CosmicNonCodingVariants_GRCh38_v94.normal.vcf.gz
     * uranus_v2_panel_sorted_int.bed.gz
     * haemonc_1706_samples.vcf.gz
 * Plugin annotations:
-    * whole_genome_SNVs.tsv.gz
-    * gnomad.genomes.r3.0.indel.tsv.gz
+    * CADD
+        * whole_genome_SNVs.tsv.gz
+        * gnomad.genomes.r3.0.indel.tsv.gz
+* VEP Annotation
+    * gnomad_AF (exome)
 
 Notes
 How to check the names of all the files included in the config:

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -127,6 +127,7 @@
         "HGVSp",
         "HGVSg",
         "HGVS_OFFSET",
-        "STRAND"
+        "STRAND",
+        "Existing_variation"
     ]
   }

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -87,7 +87,7 @@
       {
         "name": "CADD",
         "pm_file": "file-G620928433Gy9p2b27zb8JFV",
-        "required_fields":"gnomAD_AF,CADD_PHRED",
+        "required_fields":"CADD_PHRED",
         "resource_files": [
           {
             "file_id": "file-G61xfZ0433Gj2vJ7P8k9ky2Z",
@@ -112,6 +112,7 @@
         "HGVSp",
         "HGVSg",
         "HGVS_OFFSET",
-        "STRAND"
+        "STRAND",
+        "gnomAD_AF"
     ]
   }

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -1,0 +1,90 @@
+  {
+    "config_information":{
+        "genome_build": "GRCh38",
+        "assay":"Uranus",
+        "config_version": "1.0.0"
+    },
+        "vep_resources":{
+        "vep_docker":"file-G61zff8433Gy2KQX7Q2z150B",
+        "vep_cache":"file-G61yF38433GQgP504Px5PZ4G",
+        "plugin_config":"file-G61zfvj433GxkQXF414xP1yF",
+        "reference_fasta":"file-G61y95Q433Gk05zyFKF9kFv2",
+        "reference_fai":"file-G61yBV8433GjbVj022PyV3K5",
+        "reference_gzi":"file-G61yBf0433Gp4BBVGj0jxqvP",
+        "ref_bcftools":"file-Fy4j2G04qB6zQK885B5Q8Pqp"
+    },
+    "custom_annotations": [
+      {
+        "name": "ClinVar",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "CLNSIG,CLNREVSTAT,CLNDN,CLNSIGCONF",
+        "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
+        "resource_files": [
+          {
+          "file_id":"file-Gf03jZj42VYZy6kzQ895pFQf",
+          "index_id":"file-Gf03kZ042VYz0Gz1496XQgj6"
+          }
+        ]
+      },
+      {
+        "name": "panel",
+        "type": "bed",
+        "annotation_type": "overlap",
+        "force_coordinates": "0",
+        "required_fields": "panel",
+        "resource_files": [
+          {
+          "file_id":"file-GgKzZP047xBYg0xpqp2Y6g0B",
+          "index_id":"file-GgKzZX047xBQ3Y9PY4XQGj7X"
+          }
+        ]
+      },
+      {
+        "name": "Prev_Count",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AC,NS",
+        "required_fields": "Prev_Count_AC,Prev_Count_NS",
+        "resource_files": [
+          {
+          "file_id":"file-GZJFvq043bFzkk3xBxY6GZyX",
+          "index_id":"file-GZJFvq043bFyG614g32P3K59"
+          }
+        ]
+      }
+    ],
+    "plugins": [
+      {
+        "name": "CADD",
+        "pm_file": "file-G620928433Gy9p2b27zb8JFV",
+        "required_fields":"CADD_PHRED",
+        "resource_files": [
+          {
+            "file_id": "file-G61xfZ0433Gj2vJ7P8k9ky2Z",
+            "index_id": "file-G61y4Y8433GvyjJ52Fj5XjY5"
+          },
+          {
+            "file_id": "file-G61xbP0433GqX36p8QQxP3PV",
+            "index_id": "file-G61xf3j433Gz49jf6XjKG4F0"
+          }
+        ]
+      }
+    ],
+    "additional_fields":[
+        "Allele",
+        "SYMBOL",
+        "Consequence",
+        "IMPACT",
+        "EXON",
+        "INTRON",
+        "Feature",
+        "HGVSc",
+        "HGVSp",
+        "HGVSg",
+        "HGVS_OFFSET",
+        "STRAND"
+    ]
+  }

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -27,7 +27,22 @@
           "index_id":"file-Gf03kZ042VYz0Gz1496XQgj6"
           }
         ]
-      },{
+      },
+      {
+        "name": "gnomADe",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AC,AN,AF,",
+        "required_fields":"gnomADe_AC,gnomADe_AN,gnomADe_AF",
+        "resource_files": [
+          {
+          "file_id": "file-GgPVKF043kgZKfyz10Zjkj28",
+          "index_id":"file-GgPVKj043kgXfp72k59kQ8jQ"
+          }
+        ]
+      },
+      {
         "name": "COSMICcMuts",
         "type": "vcf",
         "annotation_type": "exact",
@@ -112,7 +127,6 @@
         "HGVSp",
         "HGVSg",
         "HGVS_OFFSET",
-        "STRAND",
-        "gnomAD_AF"
+        "STRAND"
     ]
   }

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-Gf03jZj42VYZy6kzQ895pFQf",
-          "index_id":"file-Gf03kZ042VYz0Gz1496XQgj6"
+          "file_id":"file-GgBzkG049vk6F62Pkqppg7zY",
+          "index_id":"file-GgBzpYQ4F82VKq8JxBv9Y058"
           }
         ]
       },

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -71,11 +71,11 @@
         ]
       },
       {
-        "name": "panel",
+        "name": "PANEL",
         "type": "bed",
         "annotation_type": "overlap",
         "force_coordinates": "0",
-        "required_fields": "panel",
+        "required_fields": "PANEL",
         "resource_files": [
           {
           "file_id":"file-GgZyv0j47xBzbYvvBQFG2QP5",

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -51,8 +51,8 @@
         "required_fields":"COSMICcMuts",
         "resource_files": [
           {
-          "file_id":"file-G64Jfk0433GVp0JJPZ4Q8FzJ",
-          "index_id":"file-G64K4bj433GZ35xJJ7YXGvzv"
+          "file_id":"file-Gf02Fxj4Pj2vPPV0zyfpbFkz",
+          "index_id":"file-Gf02JgQ4Pj2xZg2b1g9pVV7g"
           }
         ]
       },
@@ -65,8 +65,8 @@
         "required_fields":"COSMICncMuts",
         "resource_files": [
           {
-          "file_id":"file-G64K0VQ433GV03462J6GXb9Z",
-          "index_id":"file-G64K4j8433Gb0PgpFgbzjj1b"
+          "file_id":"file-Gf02Jj04Pj2ZPxF97V6YJFKv",
+          "index_id":"file-Gf02KG84Pj2QB86kK721B9yQ"
           }
         ]
       },
@@ -78,8 +78,8 @@
         "required_fields": "panel",
         "resource_files": [
           {
-          "file_id":"file-GgKzZP047xBYg0xpqp2Y6g0B",
-          "index_id":"file-GgKzZX047xBQ3Y9PY4XQGj7X"
+          "file_id":"file-GgZyv0j47xBzbYvvBQFG2QP5",
+          "index_id":"file-GgZyv1j47xBp4Jg5pgQ5gFGG"
           }
         ]
       },

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -27,6 +27,33 @@
           "index_id":"file-Gf03kZ042VYz0Gz1496XQgj6"
           }
         ]
+      },{
+        "name": "COSMICcMuts",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "",
+        "required_fields":"COSMICcMuts",
+        "resource_files": [
+          {
+          "file_id":"file-G64Jfk0433GVp0JJPZ4Q8FzJ",
+          "index_id":"file-G64K4bj433GZ35xJJ7YXGvzv"
+          }
+        ]
+      },
+      {
+        "name": "COSMICncMuts",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "",
+        "required_fields":"COSMICncMuts",
+        "resource_files": [
+          {
+          "file_id":"file-G64K0VQ433GV03462J6GXb9Z",
+          "index_id":"file-G64K4j8433Gb0PgpFgbzjj1b"
+          }
+        ]
       },
       {
         "name": "panel",
@@ -60,7 +87,7 @@
       {
         "name": "CADD",
         "pm_file": "file-G620928433Gy9p2b27zb8JFV",
-        "required_fields":"CADD_PHRED",
+        "required_fields":"gnomAD_AF,CADD_PHRED",
         "resource_files": [
           {
             "file_id": "file-G61xfZ0433Gj2vJ7P8k9ky2Z",


### PR DESCRIPTION
First version a working VEP config to annotate Uranus VCF (https://platform.dnanexus.com/panx/projects/GgZ88k842fffzg7PvXBj7zbf/monitor/job/GgZqjVQ42ffYzGQYk9vyXKZP)

Most of the annotation sources (except gnomad and panel) should match what is currently being used to annotate VCFs. What is currently used is documented on the MYE conductor (https://github.com/eastgenomics/eggd_conductor_configs/tree/main/assay_configs/MYE)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_uranus_config/1)
<!-- Reviewable:end -->
