### PR TITLE
URA-569 Add variant class

### DIFF
--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -43,20 +43,30 @@
         ]
       },
       {
-        "name": "COSMIC",
+        "name": "COSMICcMuts",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
-        "vcf_fields": "ID",
-        "required_fields":"COSMIC",
+        "vcf_fields": "",
+        "required_fields":"COSMICcMuts",
         "resource_files": [
           {
           "file_id":"file-Gf02Fxj4Pj2vPPV0zyfpbFkz",
           "index_id":"file-Gf02JgQ4Pj2xZg2b1g9pVV7g"
-          },
+          }
+        ]
+      },
+      {
+        "name": "COSMICncMuts",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "",
+        "required_fields":"COSMICncMuts",
+        "resource_files": [
           {
-            "file_id":"file-Gf02Jj04Pj2ZPxF97V6YJFKv",
-            "index_id":"file-Gf02KG84Pj2QB86kK721B9yQ"
+          "file_id":"file-Gf02Jj04Pj2ZPxF97V6YJFKv",
+          "index_id":"file-Gf02KG84Pj2QB86kK721B9yQ"
           }
         ]
       },
@@ -118,6 +128,7 @@
         "HGVSg",
         "HGVS_OFFSET",
         "STRAND",
-        "Existing_variation"
+        "Existing_variation",
+        "VARIANT_CLASS"
     ]
   }

--- a/uranus_vep_config_v1.0.0.json
+++ b/uranus_vep_config_v1.0.0.json
@@ -43,30 +43,20 @@
         ]
       },
       {
-        "name": "COSMICcMuts",
+        "name": "COSMIC",
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
-        "vcf_fields": "",
-        "required_fields":"COSMICcMuts",
+        "vcf_fields": "ID",
+        "required_fields":"COSMIC",
         "resource_files": [
           {
           "file_id":"file-Gf02Fxj4Pj2vPPV0zyfpbFkz",
           "index_id":"file-Gf02JgQ4Pj2xZg2b1g9pVV7g"
-          }
-        ]
-      },
-      {
-        "name": "COSMICncMuts",
-        "type": "vcf",
-        "annotation_type": "exact",
-        "force_coordinates": "0",
-        "vcf_fields": "",
-        "required_fields":"COSMICncMuts",
-        "resource_files": [
+          },
           {
-          "file_id":"file-Gf02Jj04Pj2ZPxF97V6YJFKv",
-          "index_id":"file-Gf02KG84Pj2QB86kK721B9yQ"
+            "file_id":"file-Gf02Jj04Pj2ZPxF97V6YJFKv",
+            "index_id":"file-Gf02KG84Pj2QB86kK721B9yQ"
           }
         ]
       },


### PR DESCRIPTION
Currently VCFs gets annotated with variant_class field (https://github.com/eastgenomics/eggd_vcf_handler_for_uranus/blob/main/src/code.sh#L22) but i forgot to add it into the first PR and realised later when testing :upside_down_face: 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_uranus_config/2)
<!-- Reviewable:end -->
