### PR TITLE
Di 1765 v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This json file provides information about annotations,plugins, required fields a
     * COSMIC
         * CosmicCodingMuts_GRCh38_v100.normal.vcf.gz
         * CosmicNonCodingVariants_GRCh38_v100.normal.vcf.gz
-    * uranus_panel_v2_annotation_for_vep.bed.gz
+    * uranus_panel_v2_annotation_for_vep_v1.1.0.sorted.bed.gz
     * haemonc_1706_samples_withoutchr.vcf.gz
     * uranus_variants_rescue_list_nochr_v1.1.sorted.bed.gz
     * haemonc_annotation_VCF_20250224_102322.vcf.gz

--- a/uranus_vep_config_v1.3.0.json
+++ b/uranus_vep_config_v1.3.0.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"Uranus",
-        "config_version": "1.2.1"
+        "config_version": "1.3.0"
     },
         "vep_resources":{
         "vep_docker":"file-G61zff8433Gy2KQX7Q2z150B",
@@ -92,8 +92,8 @@
         "required_fields": "PANEL",
         "resource_files": [
           {
-          "file_id":"file-GqFYKg047xBz592zG9JB09Jx",
-          "index_id":"file-GqFYKj847xBp6yV4px05VfjQ"
+          "file_id":"file-Gzq4P9j4BX2j5YJJ15G7qQ47",
+          "index_id":"file-Gzq59KQ4BX2bZp5F9QG15Y9j"
           }
         ]
       },


### PR DESCRIPTION
Update to use latest uranus panel bed file which has:
- Regions specified in bed file now sorted in chromosomal order, then by region, as opposed to being sorted lexicographically    
- Included the IRF4 region for the Lymphoid and T-NHL panels

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_uranus_config/14)
<!-- Reviewable:end -->
