### PR TITLE
Updated to include new haemonc capture bed, gnomADe/g 4.1 and SpliceAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ This json file provides information about annotations,plugins, required fields a
 * Custom Annotation sources:
     * ClinVar
         * clinvar_20250312_GRCh38.vcf.gz
-    * gnomAD
-        *   gnomad.exomes.r2.1.1.sites.all.liftover_grch38.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
+    * gnomADe
+        *   gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
+    * gnomADg
+        *   gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
     * COSMIC
         * CosmicCodingMuts_GRCh38_v100.normal.vcf.gz
         * CosmicNonCodingVariants_GRCh38_v100.normal.vcf.gz
@@ -32,6 +34,9 @@ This json file provides information about annotations,plugins, required fields a
     * uranus_variants_rescue_list_nochr_v1.1.sorted.bed.gz
     * haemonc_annotation_VCF_20250224_102322.vcf.gz
 * Plugin annotations:
+    * SpliceAI
+        * spliceai_scores.masked.snv.hg38.vcf.gz
+        * spliceai_scores.masked.indel.hg38.vcf.gz
     * CADD
         * whole_genome_SNVs.tsv.gz
         * gnomad.genomes.r3.0.indel.tsv.gz

--- a/uranus_vep_config_v2.0.0.json
+++ b/uranus_vep_config_v2.0.0.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"Uranus",
-        "config_version": "1.3.0"
+        "config_version": "2.0.0"
     },
         "vep_resources":{
         "vep_docker":"file-G61zff8433Gy2KQX7Q2z150B",
@@ -51,8 +51,22 @@
         "required_fields":"gnomADe_AC,gnomADe_AN,gnomADe_AF",
         "resource_files": [
           {
-          "file_id": "file-GgPVk8j43kgkz5KgkfX2Y0y0",
-          "index_id":"file-GgPVkZ043kgX7KPBYq8g17vQ"
+          "file_id": "file-GvJqP704JBpk2YBB1PzJQkb2",
+          "index_id":"file-GvJqPxQ4JBpz9y18zPg7f5F0"
+          }
+        ]
+      },
+      {
+        "name": "gnomADg",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AC,AN,AF",
+        "required_fields":"gnomADg_AC,gnomADg_AN,gnomADg_AF",
+        "resource_files": [
+          {
+          "file_id": "file-Gv81v784JBpxkK585b4FY9b2",
+          "index_id":"file-GvZBvy84JBpYG2yypqQPq3zP"
           }
         ]
       },
@@ -92,8 +106,8 @@
         "required_fields": "PANEL",
         "resource_files": [
           {
-          "file_id":"file-Gzq4P9j4BX2j5YJJ15G7qQ47",
-          "index_id":"file-Gzq59KQ4BX2bZp5F9QG15Y9j"
+          "file_id":"file-Gzg6PX04pV02bKzZY4yyxxvK",
+          "index_id":"file-Gzg6Pf84pV0KXQ5yjXkYb8Vf"
           }
         ]
       },
@@ -126,6 +140,23 @@
       }
     ],
     "plugins": [
+      {
+        "name": "SpliceAI",
+        "pm_file": "file-Gzky8384qj7jGf8bGK2QPqVY",
+        "required_fields":"SpliceAI_pred_DS_AG,SpliceAI_pred_DS_AL,SpliceAI_pred_DS_DG,SpliceAI_pred_DS_DL,SpliceAI_pred_DP_AG,SpliceAI_pred_DP_AL,SpliceAI_pred_DP_DG,SpliceAI_pred_DP_DL",
+        "resource_files": [
+          {
+            "file_id": "file-G9FFZ18433GpzFVy9XxfyBG4",
+            "index_id": "file-G9FFZb8433GvX5jJ23bQB2z7",
+            "prefix": "snv="
+          },
+          {
+            "file_id": "file-G9FFGbQ433GbXjxQBYy79X75",
+            "index_id": "file-G9FFGX0433GqkpYv23jB853V",
+            "prefix": "indel="
+          }
+        ]
+      },
       {
         "name": "CADD",
         "pm_file": "file-G620928433Gy9p2b27zb8JFV",


### PR DESCRIPTION
config_version was updated from v1.3.0 to v2.0.0

Panel bed files, file_id and index_id were updated to point to the latest uranus vep panel bed (file-Gzg6PX04pV02bKzZY4yyxxvK and file-Gzg6Pf84pV0KXQ5yjXkYb8Vf)

gnomADe files, file_id and index_id were updated to point to the latest gnomAD version4.1 (file-GvJqP704JBpk2YBB1PzJQkb2 and file-GvJqPxQ4JBpz9y18zPg7f5F0)

gnomADg custom annotation was added, file_id and index_id point to the latest gnomAD version4.1 (file-Gv81v784JBpxkK585b4FY9b2 and file-GvZBvy84JBpYG2yypqQPq3zP)

SpliceAI custom annotation was added:

for indels, file_ID and index_id (file-G9FFGbQ433GbXjxQBYy79X75 and file-9FFGX0433GqkpYv23jB853V)

for snvs, file_ID and index_id (file-G9FFZ18433GpzFVy9XxfyBG4 and file-G9FFZb8433GvX5jJ23bQB2z7)