### PR TITLE
Update to clinvar 20250415

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
     * GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz
 * Custom Annotation sources:
     * ClinVar
-        * clinvar_20250312_GRCh38.vcf.gz
+        * clinvar_20250415_GRCh38.vcf.gz
     * gnomAD
         *   gnomad.exomes.r2.1.1.sites.all.liftover_grch38.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
     * COSMIC

--- a/uranus_vep_config_v1.3.1.json
+++ b/uranus_vep_config_v1.3.1.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"Uranus",
-        "config_version": "1.3.0"
+        "config_version": "1.3.1"
     },
         "vep_resources":{
         "vep_docker":"file-G61zff8433Gy2KQX7Q2z150B",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GzG0zKQ4Q8vbff8B7j1VP1Q8",
-          "index_id":"file-GzG12x043zxykQqyB7QPvf09"
+          "file_id":"file-J03jqf04XYKGP6b0q38724k2",
+          "index_id":"file-J03jqq841VyX8F50kjq0p858"
           }
         ]
       },


### PR DESCRIPTION
Existing uranus_vep_config file was renamed by using git mv to increase version in the filename (i.e. from v1.3.0 to v1.3.1). Within the file:

config_version was updated from v1.3.0 to v1.3.1

ClinVar files, file_id and index_id  were updated to point to the most recent ClinVar annotation files (file-J03jqf04XYKGP6b0q38724k2 and file-J03jqq841VyX8F50kjq0p858)

README file was updated to point to the correct ClinVar files (version 20250415)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_uranus_config/17)
<!-- Reviewable:end -->
